### PR TITLE
fix: inherit JSON schema trusted domains

### DIFF
--- a/src/client/utils/urlMatch.ts
+++ b/src/client/utils/urlMatch.ts
@@ -3,7 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Uri } from 'vscode';
+import { Uri, workspace } from 'vscode';
+
+const sharedTrustedDomainsSetting = 'json.schemaDownload.trustedDomains';
 
 /**
  * Check whether a URL matches the list of trusted domains or URIs.
@@ -22,7 +24,13 @@ export function matchesUrlPattern(url: Uri, trustedDomains: Record<string, boole
 		return true;
 	}
 
-	for (const [pattern, isTrusted] of Object.entries(trustedDomains)) {
+	const sharedTrustedDomains = workspace.getConfiguration().get<Record<string, boolean>>(sharedTrustedDomainsSetting, {});
+	const trustedDomainEntries = [
+		...Object.entries(trustedDomains),
+		...Object.entries(sharedTrustedDomains),
+	];
+
+	for (const [pattern, isTrusted] of trustedDomainEntries) {
 		if (typeof pattern !== 'string' || pattern.trim() === '') {
 			continue;
 		}


### PR DESCRIPTION
## Summary

Honor VS Code's `json.schemaDownload.trustedDomains` setting when checking whether a remote schema URL is trusted.

Better JSON5 continues to support its existing `json5.schemaDownload.trustedDomains` setting. The extension-specific entries are checked first, followed by the shared VS Code JSON entries.

## Problem

A schema URL trusted through VS Code's built-in JSON setting was still rejected when opening a JSON5 document:

```json
{
  "json.schemaDownload.trustedDomains": {
    "https://raw.githubusercontent.com/SchemaStore/schemastore/": true
  }
}
````

Better JSON5 only checked `json5.schemaDownload.trustedDomains`, so the document reported:

```text
Location ... is untrusted
json(65538)
```

This is surprising because the same schema URL is already trusted for VS Code's JSON language support.

## Changes

* Read `json.schemaDownload.trustedDomains` in addition to `json5.schemaDownload.trustedDomains`.
* Preserve support for the existing Better JSON5-specific setting.
* Keep Better JSON5-specific entries ahead of the shared JSON entries during matching.

## Verification

Tested with VS Code 1.129.1 and Yarn 4.5.0.

Build checks:

* `yarn install --immutable`
* `yarn compile-dbg`

Both completed successfully.

The behavior was also verified in an isolated temporary VS Code profile to prevent existing global Better JSON5 settings from affecting the comparison.

### Before the change

Opening a JSON5 document whose schema was trusted only through `json.schemaDownload.trustedDomains` produced:

```text
Location ... is untrusted
json(65538)
```

### After the change

The trust error disappeared and the schema was loaded successfully.

Verified schema functionality included:

* `name: 123` reported `Incorrect type. Expected "string".`
* The language status showed `Schema validated` and `JSON schema configured`.
* Hovering over `name` showed `The name of the package.`
* Completion included `version`, `description`, and `dependencies`.
* Changing the value to `name: "test"` reduced the problem count to zero.

---

This pull request was prepared by ChatGPT at the explicit request of, and with approval from the user.